### PR TITLE
feat: add flag to prefer older gen7 sprites over gen8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "pokeget"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "Inflector",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pokeget"
 authors = [ "talwat" ]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 description = "Display pokemon sprites in your terminal."
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,4 +53,8 @@ pub struct Args {
     /// Display the female variant of the pokemon if it exists. This doesn't apply to nidoran, for some reason.
     #[arg(long, default_value_t = false)]
     pub female: bool,
+
+    /// Display older gen7 sprite if available
+    #[arg(long, default_value_t = false)]
+    pub gen7: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod utils;
 #[derive(RustEmbed)]
 #[folder = "data/"]
 #[include = "pokesprite/pokemon-gen8/*"]
+#[include = "pokesprite/pokemon-gen7x/*"]
 #[include = "pokemon.txt"]
 pub struct Data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     let mut pokemons = args.pokemon;
 
     let (width, height, sprites) =
-        get_sprites(&mut pokemons, args.shiny, args.female, &form, &list);
+        get_sprites(&mut pokemons, args.shiny, args.female, args.gen7, &form, &list);
     let combined = combine_sprites(width, height, &sprites);
 
     if !args.hide_name {


### PR DESCRIPTION
This PR adds an additional `--gen7` flag to prefer the use of the older, and smaller generation 7 sprites. It fallback to gen8 folder if the sprite does not exist in gen7x

Slight downside: larger binary to include the gen7x sprites and the gen8 sprites

Edit: I added a version bump and rephrased the commit message to be closer to what you have done in the past