### PR TITLE
correct comparison with pokeshell

### DIFF
--- a/OTHER_PROJECTS.md
+++ b/OTHER_PROJECTS.md
@@ -12,9 +12,9 @@ However, it also requires the actual sprite files be on your machine, so it isn'
 
 ## [pokeshell](https://github.com/acxz/pokeshell)
 
-It is written in pure bash, but calls terminal image viewers like [timg](https://github.com/hzeller/timg)/[chafa](https://github.com/hpjansson/chafa) for display so it is slower.
+It is written in bash, but calls terminal image viewers like [timg](https://github.com/hzeller/timg)/[chafa](https://github.com/hpjansson/chafa) for display so it is significantly slower.
 
-Other than that, it's extremely feature rich with resizing for terminal fit, tab completions, animations and more.
+Other than that, it's extremely feature rich but is also far heavier because of timg & chafa.
 
 ## [krabby](https://github.com/yannjor/krabby)
 

--- a/OTHER_PROJECTS.md
+++ b/OTHER_PROJECTS.md
@@ -12,9 +12,9 @@ However, it also requires the actual sprite files be on your machine, so it isn'
 
 ## [pokeshell](https://github.com/acxz/pokeshell)
 
-It suffers from blurry sprites at times due to using timg, which wasn't designed for pixel art.
+It is written in pure bash, but calls terminal image viewers like [timg](https://github.com/hzeller/timg)/[chafa](https://github.com/hpjansson/chafa) for display so it is slower.
 
-Other than that, it's still extremely feature rich with animations and a lot of extremely cool stuff.
+Other than that, it's extremely feature rich with resizing for terminal fit, tab completions, animations and more.
 
 ## [krabby](https://github.com/yannjor/krabby)
 


### PR DESCRIPTION
Hey @talwat I'm glad you did a rewrite of pokeget in rust! (A bit sad to see the big sprites to go tho...)

I saw the comparison with pokeshell and wanted to correct it. _Because_ pokeshell uses timg, it _is_ pixel perfect, any blurriness you would see would be when the pokemon you want to display don't fit in your current terminal size, so timg/chafa scales the image to fit. pokeget on the other hand doesn't even handle this case and floods the terminal output.

I thought this was quite unfair to pokeshell and corrected the comparison blurb with pokeshell.

btw if you do see something that is blurry (not due to resizing) please let me know/open an issue.