### PR TITLE
fix: handle exception on pokedex id index error

### DIFF
--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -45,7 +45,14 @@ impl Selection {
     pub fn eval(self, list: &List) -> String {
         match self {
             Selection::Random => list.random(),
-            Selection::DexId(id) => list.get_by_id(id).unwrap().clone(),
+            Selection::DexId(id) => list
+                .get_by_id(id)
+                .unwrap_or_else(|| {
+                    // add 1 to id so that error message matches user input
+                    eprintln!("{} is not a valid pokedex ID", id + 1);
+                    exit(1)
+                })
+                .clone(),
             Selection::Name(name) => name,
         }
     }


### PR DESCRIPTION
Currently, there is a panic when the user inputs a pokedex ID which is not a valid pokesprite index.

To recreate this error, run the following command with `pokeget-rs` installed:
```sh
pokeget 906
```

The above command yields the following error:
```
thread 'main' panicked at src/pokemon.rs:48:56:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This commit manages error handling in this case. Instead of the above error, the following error is returned:
```
906 is not a valid pokedex ID
```