### PR TITLE
feat: add region-based random pokemon selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ so using it on shell initialization is also not a very large bottleneck.
 
 `pokeget raichu sandslash meowth --alolan`
 
+#### Using regions
+
+`pokeget kanto`
+
 ## Installation
 
 ### Cargo *(recommended)*

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    /// The pokemon to display, use "random" to get a random pokemon
+    /// The pokemon to display, use "random" to get a random pokemon, use a region to get a random pokemon from that region
     pub pokemon: Vec<String>,
 
     /// Whether to hide the pokemon's name which appears above it

--- a/src/list.rs
+++ b/src/list.rs
@@ -5,6 +5,7 @@ use std::io::Cursor;
 use bimap::BiHashMap;
 use inflector::Inflector;
 use rand::Rng;
+use crate::pokemon::Region;
 
 /// A parsed representation of `names.csv`.
 ///
@@ -74,6 +75,25 @@ impl List {
         let mut rand = rand::thread_rng();
 
         let idx = rand.gen_range(0..self.ids.len());
+        self.ids.get_by_left(&idx).unwrap().clone()
+    }
+
+    /// Gets a random pokemon by region
+    pub fn get_by_region(&self, region: Region) -> String {
+        let mut rand = rand::thread_rng();
+
+        let region = match region {
+            Region::Kanto => 0..=151,
+            Region::Johto => 152..=251,
+            Region::Hoenn => 252..=386,
+            Region::Sinnoh => 387..=493,
+            Region::Unova => 494..=649,
+            Region::Kalos => 650..=721,
+            Region::Alola => 722..=809,
+            Region::Galar => 810..=905,
+        };
+
+        let idx = rand.gen_range(region);
         self.ids.get_by_left(&idx).unwrap().clone()
     }
 }


### PR DESCRIPTION
This PR adds support for generating a random pokemon based on its region, e.g `pokeget <region>`

Pokemon generated this way follow the same pattern as `random` in that a form will not be applied.

Currently implements regions Kanto-Galar as there is no Gen IX support in pokesprite yet, but should be easy to add when/if required.
