### PR TITLE
feat: wrap sprites to fit terminal width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "exr"
 version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,9 +620,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -623,6 +633,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -794,6 +810,7 @@ dependencies = [
  "rand 0.9.2",
  "rust-embed",
  "showie",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1042,6 +1059,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1212,16 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ image = { version = "0.25.8" }
 rand = "0.9.2"
 rust-embed = { version = "8.8.0" }
 showie = "2.0.1"
+terminal_size = "0.4.3"

--- a/src/sprites.rs
+++ b/src/sprites.rs
@@ -2,27 +2,65 @@ use image::{DynamicImage, GenericImage};
 
 use crate::pokemon::Pokemon;
 
-/// Combines several pokemon sprites into one by stitching them horizontally.
+/// Combines several pokemon sprites into a single image
 pub fn combine(pokemons: &[Pokemon]) -> DynamicImage {
-    let mut width: u32 = 0;
-    let mut height: u32 = 0;
+    let term_width = terminal_size::terminal_size()
+        .map(|(w, _)| u32::from(w.0))
+        .unwrap_or(u32::MAX);
 
-    for pokemon in pokemons {
-        width += pokemon.sprite.width() + 1;
-        if pokemon.sprite.height() > height {
-            height = pokemon.sprite.height();
+    let rows = pack_rows(pokemons, term_width);
+
+    let row_metrics: Vec<(u32, u32)> = rows
+        .iter()
+        .map(|row| {
+            let width = row
+                .iter()
+                .map(|p| p.sprite.width() + 1)
+                .sum::<u32>()
+                .saturating_sub(1);
+            let height = row.iter().map(|p| p.sprite.height()).max().unwrap_or(0);
+            (width, height)
+        })
+        .collect();
+
+    let total_width = row_metrics.iter().map(|(w, _)| *w).max().unwrap_or(0);
+    let total_height = row_metrics.iter().map(|(_, h)| *h).sum();
+
+    let mut canvas = DynamicImage::new_rgba8(total_width.max(1), total_height);
+
+    let mut current_y = 0;
+    for (row, &(_, row_height)) in rows.iter().zip(&row_metrics) {
+        let mut current_x = 0;
+
+        for pokemon in row {
+            let sprite = &pokemon.sprite;
+            let y_offset = current_y + (row_height - sprite.height());
+
+            canvas.copy_from(sprite, current_x, y_offset).unwrap();
+            current_x += sprite.width() + 1;
         }
+        current_y += row_height;
     }
 
-    let mut combined = DynamicImage::new_rgba8(width - 1, height);
-    let mut shift = 0;
+    canvas
+}
+
+/// Packs pokemon into rows that fit within max_width
+fn pack_rows<'a>(pokemons: &'a [Pokemon], max_width: u32) -> Vec<Vec<&'a Pokemon<'a>>> {
+    let mut rows: Vec<Vec<&Pokemon>> = vec![vec![]];
+    let mut current_width = 0;
 
     for pokemon in pokemons {
-        combined
-            .copy_from(&pokemon.sprite, shift, height - pokemon.sprite.height())
-            .unwrap();
-        shift += pokemon.sprite.width() + 1;
+        let w = pokemon.sprite.width() + 1;
+
+        if current_width > 0 && current_width + w > max_width {
+            rows.push(vec![]);
+            current_width = 0;
+        }
+
+        rows.last_mut().unwrap().push(pokemon);
+        current_width += w;
     }
 
-    combined
+    rows
 }


### PR DESCRIPTION
Hi, I noticed sprites overflow the terminal width when displaying many at once, so I added row wrapping to fix that. What do you think?